### PR TITLE
Lock window resolution

### DIFF
--- a/graveyard/views/assets/inlined_images.rkt
+++ b/graveyard/views/assets/inlined_images.rkt
@@ -133,8 +133,8 @@
 (define welcome-bitmap
   (compiled-bitmap
    (pict->bitmap
-    (text/font "Welcome to Queen of the Graveyard!"
-               27
+    (text/font "### Graveyard ###"
+               20
                "Goldenrod"
                "Courier"
                'decorative

--- a/graveyard/views/view.rkt
+++ b/graveyard/views/view.rkt
@@ -47,7 +47,9 @@
 
 (define game-window
   (new frame%
-       [label "Graveyard"]))
+       [label "Graveyard"]
+       [stretchable-width #f]
+       [stretchable-height #f]))
 
 (define game-pane
   (new pane%
@@ -62,10 +64,11 @@
 (define board-container vert-arranger)
 
 
+
 (define welcome-message
   (new canvas%
        [parent board-container]
-       [min-height 50]
+       [min-height 20]
        [paint-callback (lambda (me dc)
                          (send dc
                                draw-bitmap
@@ -80,8 +83,8 @@
   (new table-panel%
        [parent board-container]
        [dimensions '(1 2)]
-       [column-stretchability #t]
-       [row-stretchability #t]
+       [column-stretchability #f]
+       [row-stretchability #f]
        [alignment (list 'center 'top)]))
 
 
@@ -103,6 +106,8 @@
   (new table-panel%
        [parent board-container]
        [border 2]
+       [stretchable-width #f]
+       [stretchable-height #f]
        [dimensions (list b:board-rows b:board-columns)]
        [alignment (list 'center 'bottom)]))
 


### PR DESCRIPTION
Lock resolution of game window.

Assets already generated with fixed resolution at compile time, as image regeneration on resize a bit time consuming on lighter machines.  Given this it makes no sense to not have resolution locked.

Also reduce banner size.